### PR TITLE
Add "noise" and "gasResistance" as a data type in enums.py

### DIFF
--- a/pulseeco/api/data_types.py
+++ b/pulseeco/api/data_types.py
@@ -36,6 +36,8 @@ class OverallValues(TypedDict):
     humidity: str
     pressure: str
     noise_dba: str
+    noise: int
+    gasResistance: int
 
 
 class Overall(TypedDict):

--- a/pulseeco/enums.py
+++ b/pulseeco/enums.py
@@ -58,6 +58,7 @@ class DataValueType(StrEnum):
     HUMIDITY = "humidity"
     PRESSURE = "pressure"
     NOISE_DBA = "noise_dba"
+    NOISE = "noise"
 
 
 class AveragePeriod(StrEnum):

--- a/pulseeco/enums.py
+++ b/pulseeco/enums.py
@@ -59,7 +59,7 @@ class DataValueType(StrEnum):
     PRESSURE = "pressure"
     NOISE_DBA = "noise_dba"
     NOISE = "noise"
-
+    GAS_RESISTANCE = "gasResistance"
 
 class AveragePeriod(StrEnum):
     DAY = "day"


### PR DESCRIPTION
Some sensors returns both "noise" and "noise_dba" as types, therefore when calling `data_raw` method without a type specified you get an error `pydantic_core._pydantic_core.ValidationError: 1 validation error for DataValue
type
  Input should be 'no2', 'o3', 'pm25', 'pm10', 'temperature', 'humidity', 'pressure' or 'noise_dba' [type=enum, input_value='noise', input_type=str]`

Example for noise: https://skopje.pulse.eco/rest/dataRaw?sensorId=200cdb67-8dc5-4dcf-ac62-748db636e04e&from=2023-12-15T14:00:00%2b01:00&to=2023-12-21T15:00:00%2b01:00
![image](https://github.com/martinkozle/pulse-eco/assets/2308950/af31265e-36e7-43ca-9c48-b4319038bbd4)

Example for gasResistance: https://skopje.pulse.eco/rest/dataRaw?sensorId=60aa65c6-b7c4-4aae-8769-5dbcba3
56b5d&from=2023-12-15T14:00:00%2b01:00&to=2023-12-21T15:00:00%2b01:00

![image](https://github.com/martinkozle/pulse-eco/assets/2308950/257cec52-a915-4c6b-9b89-101aebe347cf)
