### PR TITLE
Modularity

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,33 @@ pulse.eco client for Python.
 
 ## Installation
 
-pulse-eco is avialiable on [PyPI](https://pypi.org/project/pulse-eco):
+Requires Python version 3.8+.
+
+The `pulse-eco` package comes with no base dependencies, everything is an extra. A sensible default is:
 
 ```console
-python -m pip install pulse-eco
+python -m pip install pulse-eco[client,httpx]
 ```
 
-Requires Python version 3.8+.
+### List of extras
+
+- `client` - includes Pydantic, used for the higher level validated client (`pulseeco.client`).
+- `requests` - includes [requests](https://requests.readthedocs.io/en/latest/) HTTP client with sync support.
+- `aiohttp` - includes [aiohttp](https://docs.aiohttp.org/en/stable/) HTTP client with async support.
+- `httpx` - includes [HTTPX](https://www.python-httpx.org/) HTTP client with both sync and async support.
 
 ## Documentation
 
-Official pulse.eco REST API documentation can be found on  [pulse.eco/restapi](https://pulse.eco/restapi).
-
 API Reference and User Guide for this package is available on [GitHub Pages](https://martinkozle.github.io/pulse-eco/).
+
+Official pulse.eco REST API documentation can be found on [pulse.eco/restapi](https://pulse.eco/restapi).
 
 ## Requesting data with a larger time range
 
 The pulse.eco API limits the maximum time span of data you can get from one request.
 For `/dataRaw` it is one week, while for `/avgData` it is one year.
 
-If the time range is larger than the maximum, the pulse.eco client creates multiple requests to the API and then joins the data together. Be aware of this.
+If the time range is larger than the maximum, the pulse-eco Python client performs multiple requests to the API and then joins the data together. Be aware of this.
 
 ## Development
 
@@ -50,6 +57,12 @@ Activate a Python 3.8 environment and run:
 
 ```console
 hatch env create dev
+```
+
+To delete the environment, run:
+
+```console
+hatch env remove dev
 ```
 
 ### Install pre-commit hooks

--- a/hatch.toml
+++ b/hatch.toml
@@ -6,8 +6,11 @@ test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report --show-missing"]
 cov-xml = "coverage xml"
 cov = ["test-cov", "cov-report", "cov-xml"]
-typing = "mypy ."
-style = ["ruff check .", "ruff format --check --diff {args:pulseeco tests}"]
+typing = "mypy {args:pulseeco tests}"
+style = [
+    "ruff check {args:pulseeco tests}",
+    "ruff format --check --diff {args:pulseeco tests}",
+]
 fmt = [
     "ruff check --fix {args:pulseeco tests}",
     "ruff format {args:pulseeco tests}",

--- a/mkdocs/example-usage.md
+++ b/mkdocs/example-usage.md
@@ -5,7 +5,7 @@
 Authentication is not required for fetching data. But if provided, it has to be valid. Authentication is per city.
 
 ```python
-from pulseeco import PulseEcoClient
+from pulseeco.client import PulseEcoClient
 
 pulse_eco = PulseEcoClient(city_name="skopje", auth=("user", "pass"))
 ```
@@ -63,7 +63,7 @@ Sensor(
 
 ```pycon
 >>> import datetime
->>> from pulseeco import DataValueType
+>>> from pulseeco.client import DataValueType
 >>> pulse_eco.data_raw(
 ...   from_=datetime.datetime(year=2017, month=3, day=15, hour=2),
 ...   to=datetime.datetime(year=2017, month=4, day=19, hour=12),
@@ -85,7 +85,7 @@ sensor_id `"-1"` is a magic value that gives average values for the whole city.
 
 ```pycon
 >>> import datetime
->>> from pulseeco import AveragePeriod, DataValueType
+>>> from pulseeco.client import AveragePeriod, DataValueType
 >>> pulse_eco.avg_data(
 ...   period=AveragePeriod.MONTH,
 ...   from_=datetime.datetime(year=2019, month=3, day=1, hour=12),

--- a/mkdocs/http-clients.md
+++ b/mkdocs/http-clients.md
@@ -1,0 +1,53 @@
+# HTTP Client
+
+The `pulse-eco` package is designed to be modular and compatible with different HTTP clients.
+
+## Supported clients
+
+The following HTTP clients are currently supported:
+
+### Sync
+
+- `requests`
+- `httpx`
+
+### Async
+
+- `aiohttp`
+- `httpx`
+
+## Context management
+
+It is recommended to always use context managers when working with HTTP clients.
+
+Examples:
+
+```python
+import requests
+
+from pulseeco.client import PulseEcoClient
+
+with requests.Session() as client:
+    pulse_eco = PulseEcoClient(city_name="skopje", client=client)
+    pulse_eco.sensors()
+```
+
+```python
+import aiohttp
+
+from pulseeco.client import PulseEcoClient
+
+async with aiohttp.ClientSession() as client:
+    pulse_eco = PulseEcoClient(city_name="skopje", async_client=client)
+    await pulse_eco.asensors()
+```
+
+```python
+import httpx
+
+from pulseeco.client import PulseEcoClient
+
+async with httpx.AsyncClient() as client:
+    pulse_eco = PulseEcoClient(city_name="skopje", async_client=client)
+    await pulse_eco.asensors()
+```

--- a/pulseeco/__init__.py
+++ b/pulseeco/__init__.py
@@ -1,10 +1,26 @@
-from .client import PulseEcoClient
-from .enums import AveragePeriod, DataValueType, SensorStatus, SensorType
+from importlib.util import find_spec
 
-__all__ = [
-    "AveragePeriod",
-    "DataValueType",
-    "PulseEcoClient",
-    "SensorStatus",
-    "SensorType",
-]
+if find_spec("pydantic") is not None:
+    from .client import (
+        AveragePeriod,
+        DataValue,
+        DataValueType,
+        Overall,
+        OverallValues,
+        PulseEcoClient,
+        Sensor,
+        SensorStatus,
+        SensorType,
+    )
+
+    __all__ = [
+        "AveragePeriod",
+        "DataValue",
+        "DataValueType",
+        "Overall",
+        "OverallValues",
+        "PulseEcoClient",
+        "Sensor",
+        "SensorStatus",
+        "SensorType",
+    ]

--- a/pulseeco/api/__init__.py
+++ b/pulseeco/api/__init__.py
@@ -1,3 +1,19 @@
+from .data_types import (
+    DataValueAvg,
+    DataValueBase,
+    DataValueRaw,
+    Overall,
+    OverallValues,
+    Sensor,
+)
 from .pulse_eco_api import PulseEcoAPI
 
-__all__ = ["PulseEcoAPI"]
+__all__ = [
+    "DataValueAvg",
+    "DataValueBase",
+    "DataValueRaw",
+    "Overall",
+    "OverallValues",
+    "PulseEcoAPI",
+    "Sensor",
+]

--- a/pulseeco/api/base.py
+++ b/pulseeco/api/base.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import datetime
 
-    from pulseeco.api.data_types import DataValueAvg, DataValueRaw, Overall, Sensor
+    from .data_types import DataValueAvg, DataValueRaw, Overall, Sensor
 
 from abc import ABC, abstractmethod
 
@@ -17,10 +17,25 @@ class PulseEcoAPIBase(ABC):  # pragma: no cover
     def sensors(self) -> list[Sensor]: ...
 
     @abstractmethod
+    async def asensors(self) -> list[Sensor]: ...
+
+    @abstractmethod
     def sensor(self, sensor_id: str) -> Sensor: ...
 
     @abstractmethod
+    async def asensor(self, sensor_id: str) -> Sensor: ...
+
+    @abstractmethod
     def data_raw(
+        self,
+        from_: str | datetime.datetime,
+        to: str | datetime.datetime,
+        type: str | None = None,
+        sensor_id: str | None = None,
+    ) -> list[DataValueRaw]: ...
+
+    @abstractmethod
+    async def adata_raw(
         self,
         from_: str | datetime.datetime,
         to: str | datetime.datetime,
@@ -39,10 +54,29 @@ class PulseEcoAPIBase(ABC):  # pragma: no cover
     ) -> list[DataValueAvg]: ...
 
     @abstractmethod
+    async def aavg_data(
+        self,
+        period: str,
+        from_: str | datetime.datetime,
+        to: str | datetime.datetime,
+        type: str,
+        sensor_id: str | None = None,
+    ) -> list[DataValueAvg]: ...
+
+    @abstractmethod
     def data24h(self) -> list[DataValueRaw]: ...
+
+    @abstractmethod
+    async def adata24h(self) -> list[DataValueRaw]: ...
 
     @abstractmethod
     def current(self) -> list[DataValueRaw]: ...
 
     @abstractmethod
+    async def acurrent(self) -> list[DataValueRaw]: ...
+
+    @abstractmethod
     def overall(self) -> Overall: ...
+
+    @abstractmethod
+    async def aoverall(self) -> Overall: ...

--- a/pulseeco/api/http_clients.py
+++ b/pulseeco/api/http_clients.py
@@ -7,10 +7,10 @@ has_requests = find_spec("requests") is not None
 has_aiohttp = find_spec("aiohttp") is not None
 has_httpx = find_spec("httpx") is not None
 
-if has_requests:
+if has_requests:  # pragma: no cover
     import requests  # type: ignore[import-not-found, unused-ignore]
 
-if has_httpx:
+if has_httpx:  # pragma: no cover
     import httpx  # type: ignore[import-not-found, unused-ignore]
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ class _SingleUseHttpxClient:
 _SingleUseClient = Union[_SingleUseRequestsClient, _SingleUseHttpxClient]
 
 
-def get_fallback_sync_client() -> _SingleUseClient:
+def get_fallback_sync_client() -> _SingleUseClient:  # pragma: no cover
     if has_requests:
         return _SingleUseRequestsClient()
     if has_httpx:

--- a/pulseeco/api/http_clients.py
+++ b/pulseeco/api/http_clients.py
@@ -30,7 +30,7 @@ class _SingleUseHttpxClient:
 _SingleUseClient = Union[_SingleUseRequestsClient, _SingleUseHttpxClient]
 
 
-def _get_fallback_sync_client() -> _SingleUseClient:
+def get_fallback_sync_client() -> _SingleUseClient:
     if has_requests:
         return _SingleUseRequestsClient()
     if has_httpx:

--- a/pulseeco/api/http_clients.py
+++ b/pulseeco/api/http_clients.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from importlib.util import find_spec
+from typing import TYPE_CHECKING, Union
+
+has_requests = find_spec("requests") is not None
+has_aiohttp = find_spec("aiohttp") is not None
+has_httpx = find_spec("httpx") is not None
+
+if has_requests:
+    import requests  # type: ignore[import-not-found, unused-ignore]
+
+if has_httpx:
+    import httpx  # type: ignore[import-not-found, unused-ignore]
+
+if TYPE_CHECKING:
+    import aiohttp  # type: ignore[import-not-found, unused-ignore]
+
+
+class _SingleUseRequestsClient:
+    def __init__(self) -> None:
+        self.get = requests.get
+
+
+class _SingleUseHttpxClient:
+    def __init__(self) -> None:
+        self.get = httpx.get
+
+
+_SingleUseClient = Union[_SingleUseRequestsClient, _SingleUseHttpxClient]
+
+
+def _get_fallback_sync_client() -> _SingleUseClient:
+    if has_requests:
+        return _SingleUseRequestsClient()
+    if has_httpx:
+        return _SingleUseHttpxClient()
+    raise ImportError(
+        "No supported sync http client is installed"
+        ", install one of the extras `requests` or `httpx`"
+        ", you can install either with `pip install pulse-eco[requests]`"
+        " or `pip install pulse-eco[httpx]`"
+    )
+
+
+if TYPE_CHECKING:
+    CLIENT = Union[requests.Session, httpx.Client, _SingleUseClient]
+    ASYNC_CLIENT = Union[aiohttp.ClientSession, httpx.AsyncClient]

--- a/pulseeco/api/pulse_eco_api.py
+++ b/pulseeco/api/pulse_eco_api.py
@@ -20,7 +20,7 @@ from pulseeco.utils import convert_datetime_to_str, split_datetime_span
 
 from .base import PulseEcoAPIBase
 from .data_types import DataValueAvg, DataValueRaw, Overall, Sensor
-from .http_clients import _get_fallback_sync_client
+from .http_clients import get_fallback_sync_client
 
 if TYPE_CHECKING:
     import datetime
@@ -119,7 +119,7 @@ class PulseEcoAPI(PulseEcoAPIBase):
         if client is not None:
             self._client = client
         else:
-            self._client = _get_fallback_sync_client()
+            self._client = get_fallback_sync_client()
 
         self._async_client = async_client
 

--- a/pulseeco/api/pulse_eco_api.py
+++ b/pulseeco/api/pulse_eco_api.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+import inspect
 import os
 import warnings
-from typing import TYPE_CHECKING, Any, cast
-
-import requests
+from typing import TYPE_CHECKING, Any, List, cast
 
 from pulseeco.constants import (
     AVG_DATA_MAX_SPAN,
@@ -20,9 +20,15 @@ from pulseeco.utils import convert_datetime_to_str, split_datetime_span
 
 from .base import PulseEcoAPIBase
 from .data_types import DataValueAvg, DataValueRaw, Overall, Sensor
+from .http_clients import _get_fallback_sync_client
 
 if TYPE_CHECKING:
     import datetime
+
+    from .http_clients import (
+        ASYNC_CLIENT,
+        CLIENT,
+    )
 
 
 def get_auth_from_env(city_name: str) -> tuple[str, str] | None:
@@ -74,7 +80,9 @@ class PulseEcoAPI(PulseEcoAPIBase):
         city_name: str,
         auth: tuple[str, str] | None = None,
         base_url: str = PULSE_ECO_BASE_URL_FORMAT,
-        session: requests.Session | None = None,
+        session: None = None,
+        client: CLIENT | None = None,
+        async_client: ASYNC_CLIENT | None = None,
     ) -> None:
         """Initialize the pulse.eco API wrapper.
 
@@ -82,8 +90,14 @@ class PulseEcoAPI(PulseEcoAPIBase):
         :param auth: a tuple of (email, password), defaults to None
         :param base_url: the base URL of the API, defaults to
             'https://{city_name}.pulse.eco/rest/{end_point}'
-        :param session: a requests session
-            , use this to customize the session and add retries, defaults to None
+        :param session: deprecated, use client and async_client instead
+        :param client: a sync http client, supported types are:
+            requests.Session, httpx.Client,
+            defaults to None which uses a new requests.Session for each request,
+            use a context managed session for better performance and resource management
+        :param async_client: an async http client, supported types are:
+            aiohttp.ClientSession, httpx.AsyncClient,
+            defaults to None which will use the sync client
         """
         self.city_name = city_name
 
@@ -91,15 +105,28 @@ class PulseEcoAPI(PulseEcoAPIBase):
             base_url = os.environ[PULSE_ECO_BASE_URL_FORMAT_ENV_KEY]
 
         if session is not None:
-            self._session = session
+            warnings.warn(
+                "The `session` parameter is deprecated. "
+                "Use `client` and `async_client` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        client = client if client is not None else session
+
+        self._client: CLIENT
+
+        if client is not None:
+            self._client = client
         else:
-            self._session = requests.Session()
+            self._client = _get_fallback_sync_client()
+
+        self._async_client = async_client
 
         if auth is None:
             auth = get_auth_from_env(city_name=city_name)
 
-        if auth is not None:
-            self._session.auth = auth
+        self._auth = auth
 
         self._base_url = base_url
 
@@ -115,8 +142,39 @@ class PulseEcoAPI(PulseEcoAPIBase):
         if params is None:
             params = {}
         url = self._base_url.format(city_name=self.city_name, end_point=end_point)
-        response = self._session.get(url, params=params)
+
+        # httpx does not support auth None
+        if self._auth is not None:
+            response = self._client.get(url, params=params, auth=self._auth)
+        else:
+            response = self._client.get(url, params=params)
         response.raise_for_status()
+
+        return response.json()
+
+    async def _abase_request(
+        self, end_point: str, params: dict[str, Any] | None = None
+    ) -> Any:  # noqa: ANN401
+        """Make an async request to the PulseEco API.
+
+        :param end_point: an end point of the API
+        :param params: get parameters, defaults to None
+        :return: the response json
+        """
+        if self._async_client is None:
+            return self._base_request(end_point, params)
+
+        if params is None:
+            params = {}
+
+        url = self._base_url.format(city_name=self.city_name, end_point=end_point)
+
+        response = await self._async_client.get(url, params=params)
+        response.raise_for_status()
+
+        # In case of aiohttp, the response.json() is a coroutine function
+        if inspect.iscoroutinefunction(response.json):
+            return await response.json()
         return response.json()
 
     def sensors(self) -> list[Sensor]:
@@ -124,7 +182,14 @@ class PulseEcoAPI(PulseEcoAPIBase):
 
         :return: a list of sensors
         """
-        return cast("list[Sensor]", self._base_request("sensor"))
+        return cast(List[Sensor], self._base_request("sensor"))
+
+    async def asensors(self) -> list[Sensor]:
+        """Get all sensors for a city.
+
+        :return: a list of sensors
+        """
+        return cast(List[Sensor], await self._abase_request("sensor"))
 
     def sensor(self, sensor_id: str) -> Sensor:
         """Get a sensor by it's ID
@@ -133,6 +198,14 @@ class PulseEcoAPI(PulseEcoAPIBase):
         :return: a sensor
         """
         return cast(Sensor, self._base_request(f"sensor/{sensor_id}"))
+
+    async def asensor(self, sensor_id: str) -> Sensor:
+        """Get a sensor by it's ID
+
+        :param sensor_id: the unique ID of the sensor
+        :return: a sensor
+        """
+        return cast(Sensor, await self._abase_request(f"sensor/{sensor_id}"))
 
     def data_raw(
         self,
@@ -168,11 +241,56 @@ class PulseEcoAPI(PulseEcoAPIBase):
             }
             params = {k: v for k, v in params.items() if v is not None}
             data_value = cast(
-                "list[DataValueRaw]",
+                List[DataValueRaw],
                 self._base_request("dataRaw", params=params),
             )
             data += data_value
         return data
+
+    async def adata_raw(
+        self,
+        from_: str | datetime.datetime,
+        to: str | datetime.datetime,
+        type: str | None = None,
+        sensor_id: str | None = None,
+    ) -> list[DataValueRaw]:
+        """Get raw data for a city.
+
+        :param from_: the start datetime of the data
+            as a datetime object or an isoformat string
+        :param to: the end datetime of the data
+            as a datetime object or an isoformat string
+        :param type: the data value type, defaults to None
+        :param sensor_id: the unique ID of the sensor, defaults to None
+        :return: a list of data values
+        """
+        if sensor_id is None and type is None:
+            warnings.warn(
+                "Warning! If you encounter an error, "
+                "you should probably specify either sensor_id or type.",
+                stacklevel=2,
+            )
+        coroutines: list[asyncio.Future[list[DataValueRaw]]] = []
+        datetime_spans = split_datetime_span(from_, to, DATA_RAW_MAX_SPAN)
+        for from_temp, to_temp in datetime_spans:
+            params = {
+                "sensorId": sensor_id,
+                "type": type,
+                "from": convert_datetime_to_str(from_temp),
+                "to": convert_datetime_to_str(to_temp),
+            }
+            params = {k: v for k, v in params.items() if v is not None}
+            coroutines.append(
+                cast(
+                    "asyncio.Future[list[DataValueRaw]]",
+                    self._abase_request("dataRaw", params=params),
+                )
+            )
+        return [
+            data
+            for data_value in await asyncio.gather(*coroutines)
+            for data in data_value
+        ]
 
     def avg_data(
         self,
@@ -210,11 +328,58 @@ class PulseEcoAPI(PulseEcoAPIBase):
             }
             params = {k: v for k, v in params.items() if v is not None}
             data_value = cast(
-                "list[DataValueAvg]",
+                List[DataValueAvg],
                 self._base_request(f"avgData/{period}", params=params),
             )
             data += data_value
         return data
+
+    async def aavg_data(
+        self,
+        period: str,
+        from_: str | datetime.datetime,
+        to: str | datetime.datetime,
+        type: str,
+        sensor_id: str | None = None,
+    ) -> list[DataValueAvg]:
+        """Get average data for a city.
+
+        :param period: the period of the average data (day, week, month)
+        :param from_: the start datetime of the data
+            as a datetime object or an isoformat string
+        :param to: the end datetime of the data
+            as a datetime object or an isoformat string
+        :param type: the data value type
+        :param sensor_id: the unique ID of the sensor, defaults to None
+        :return: a list of average data values
+        """
+        if period not in {"day", "week", "month"}:
+            warnings.warn(
+                "Warning! Invalid value for period. "
+                "Should be one of: day, week, month",
+                stacklevel=2,
+            )
+        coroutines: list[asyncio.Future[list[DataValueAvg]]] = []
+        datetime_spans = split_datetime_span(from_, to, AVG_DATA_MAX_SPAN)
+        for from_temp, to_temp in datetime_spans:
+            params = {
+                "sensorId": sensor_id,
+                "type": type,
+                "from": convert_datetime_to_str(from_temp),
+                "to": convert_datetime_to_str(to_temp),
+            }
+            params = {k: v for k, v in params.items() if v is not None}
+            coroutines.append(
+                cast(
+                    "asyncio.Future[list[DataValueAvg]]",
+                    self._abase_request(f"avgData/{period}", params=params),
+                )
+            )
+        return [
+            data
+            for data_value in await asyncio.gather(*coroutines)
+            for data in data_value
+        ]
 
     def data24h(self) -> list[DataValueRaw]:
         """Get 24h data for a city.
@@ -223,7 +388,16 @@ class PulseEcoAPI(PulseEcoAPIBase):
 
         :return: a list of data values for the past 24 hours
         """
-        return cast("list[DataValueRaw]", self._base_request("data24h"))
+        return cast(List[DataValueRaw], self._base_request("data24h"))
+
+    async def adata24h(self) -> list[DataValueRaw]:
+        """Get 24h data for a city.
+
+        The data values are sorted ascending by their timestamp.
+
+        :return: a list of data values for the past 24 hours
+        """
+        return cast(List[DataValueRaw], await self._abase_request("data24h"))
 
     def current(self) -> list[DataValueRaw]:
         """Get the last received valid data for each sensor in a city
@@ -232,7 +406,16 @@ class PulseEcoAPI(PulseEcoAPIBase):
 
         :return: a list of current data values
         """
-        return cast("list[DataValueRaw]", self._base_request("current"))
+        return cast(List[DataValueRaw], self._base_request("current"))
+
+    async def acurrent(self) -> list[DataValueRaw]:
+        """Get the last received valid data for each sensor in a city
+
+        Will not return sensor data older than 2 hours.
+
+        :return: a list of current data values
+        """
+        return cast(List[DataValueRaw], await self._abase_request("current"))
 
     def overall(
         self,
@@ -260,3 +443,30 @@ class PulseEcoAPI(PulseEcoAPIBase):
         :return: the overall data for the city
         """
         return cast(Overall, self._base_request("overall"))
+
+    async def aoverall(
+        self,
+    ) -> Overall:
+        """Get the current average data for all sensors per value for a city.
+
+        ## Example:
+
+        ```python
+        {
+            'cityName': 'skopje',
+            'values': {
+                'no2': '22',
+                'o3': '4',
+                'pm25': '53',
+                'pm10': '73',
+                'temperature': '7',
+                'humidity': '71',
+                'pressure': '992',
+                'noise_dba': '43'
+            }
+        }
+        ```
+
+        :return: the overall data for the city
+        """
+        return cast(Overall, await self._abase_request("overall"))

--- a/pulseeco/api/pulse_eco_api.py
+++ b/pulseeco/api/pulse_eco_api.py
@@ -104,7 +104,7 @@ class PulseEcoAPI(PulseEcoAPIBase):
         if base_url is not None and PULSE_ECO_BASE_URL_FORMAT_ENV_KEY in os.environ:
             base_url = os.environ[PULSE_ECO_BASE_URL_FORMAT_ENV_KEY]
 
-        if session is not None:
+        if session is not None:  # pragma: no cover
             warnings.warn(
                 "The `session` parameter is deprecated. "
                 "Use `client` and `async_client` instead.",

--- a/pulseeco/client/__init__.py
+++ b/pulseeco/client/__init__.py
@@ -1,0 +1,15 @@
+from .client import PulseEcoClient
+from .enums import AveragePeriod, DataValueType, SensorStatus, SensorType
+from .models import DataValue, Overall, OverallValues, Sensor
+
+__all__ = [
+    "AveragePeriod",
+    "DataValue",
+    "DataValueType",
+    "Overall",
+    "OverallValues",
+    "PulseEcoClient",
+    "Sensor",
+    "SensorStatus",
+    "SensorType",
+]

--- a/pulseeco/client/client.py
+++ b/pulseeco/client/client.py
@@ -66,6 +66,13 @@ class PulseEcoClient:
         """
         return Sensors.validate_python(self._pulse_eco_api.sensors())
 
+    async def asensors(self) -> list[Sensor]:
+        """Get all sensors for a city.
+
+        :return: a list of sensors
+        """
+        return Sensors.validate_python(await self._pulse_eco_api.asensors())
+
     def sensor(self, sensor_id: str) -> Sensor:
         """Get a sensor by it's ID.
 
@@ -73,6 +80,16 @@ class PulseEcoClient:
         :return: a sensor
         """
         return Sensor.model_validate(self._pulse_eco_api.sensor(sensor_id=sensor_id))
+
+    async def asensor(self, sensor_id: str) -> Sensor:
+        """Get a sensor by it's ID.
+
+        :param sensor_id: the unique ID of the sensor
+        :return: a sensor
+        """
+        return Sensor.model_validate(
+            await self._pulse_eco_api.asensor(sensor_id=sensor_id)
+        )
 
     def data_raw(
         self,
@@ -93,6 +110,32 @@ class PulseEcoClient:
         """
         return DataValues.validate_python(
             self._pulse_eco_api.data_raw(
+                from_=from_,
+                to=to,
+                type=type,
+                sensor_id=sensor_id,
+            )
+        )
+
+    async def adata_raw(
+        self,
+        from_: str | datetime.datetime,
+        to: str | datetime.datetime,
+        type: DataValueType | None = None,
+        sensor_id: str | None = None,
+    ) -> list[DataValue]:
+        """Get raw data for a city.
+
+        :param from_: the start datetime of the data
+            as a datetime object or an isoformat string
+        :param to: the end datetime of the data
+            as a datetime object or an isoformat string
+        :param type: the data value type, defaults to None
+        :param sensor_id: the unique ID of the sensor, defaults to None
+        :return: a list of data values
+        """
+        return DataValues.validate_python(
+            await self._pulse_eco_api.adata_raw(
                 from_=from_,
                 to=to,
                 type=type,
@@ -129,6 +172,35 @@ class PulseEcoClient:
             )
         )
 
+    async def aavg_data(
+        self,
+        period: AveragePeriod,
+        from_: str | datetime.datetime,
+        to: str | datetime.datetime,
+        type: DataValueType,
+        sensor_id: str | None = None,
+    ) -> list[DataValue]:
+        """Get average data for a city.
+
+        :param period: the period of the average data
+        :param from_: the start datetime of the data
+            as a datetime object or an isoformat string
+        :param to: the end datetime of the data
+            as a datetime object or an isoformat string
+        :param type: the data value type
+        :param sensor_id: the unique ID of the sensor, defaults to None
+        :return: a list of average data values
+        """
+        return DataValues.validate_python(
+            await self._pulse_eco_api.aavg_data(
+                period=period,
+                from_=from_,
+                to=to,
+                type=type,
+                sensor_id=sensor_id,
+            )
+        )
+
     def data24h(self) -> list[DataValue]:
         """Get 24h data for a city.
 
@@ -137,6 +209,15 @@ class PulseEcoClient:
         :return: a list of data values for the past 24 hours
         """
         return DataValues.validate_python(self._pulse_eco_api.data24h())
+
+    async def adata24h(self) -> list[DataValue]:
+        """Get 24h data for a city.
+
+        The data values are sorted ascending by their timestamp.
+
+        :return: a list of data values for the past 24 hours
+        """
+        return DataValues.validate_python(await self._pulse_eco_api.adata24h())
 
     def current(self) -> list[DataValue]:
         """Get the last received valid data for each sensor in a city.
@@ -147,9 +228,25 @@ class PulseEcoClient:
         """
         return DataValues.validate_python(self._pulse_eco_api.current())
 
+    async def acurrent(self) -> list[DataValue]:
+        """Get the last received valid data for each sensor in a city.
+
+        Will not return sensor data older than 2 hours.
+
+        :return: a list of current data values
+        """
+        return DataValues.validate_python(await self._pulse_eco_api.acurrent())
+
     def overall(self) -> Overall:
         """Get the current average data for all sensors per value for a city.
 
         :return: the overall data for the city
         """
         return Overall.model_validate(self._pulse_eco_api.overall())
+
+    async def aoverall(self) -> Overall:
+        """Get the current average data for all sensors per value for a city.
+
+        :return: the overall data for the city
+        """
+        return Overall.model_validate(await self._pulse_eco_api.aoverall())

--- a/pulseeco/client/client.py
+++ b/pulseeco/client/client.py
@@ -112,7 +112,7 @@ class PulseEcoClient:
             self._pulse_eco_api.data_raw(
                 from_=from_,
                 to=to,
-                type=type,
+                type=type.value if type is not None else None,
                 sensor_id=sensor_id,
             )
         )
@@ -138,7 +138,7 @@ class PulseEcoClient:
             await self._pulse_eco_api.adata_raw(
                 from_=from_,
                 to=to,
-                type=type,
+                type=type.value if type is not None else None,
                 sensor_id=sensor_id,
             )
         )
@@ -167,7 +167,7 @@ class PulseEcoClient:
                 period=period,
                 from_=from_,
                 to=to,
-                type=type,
+                type=type.value,
                 sensor_id=sensor_id,
             )
         )
@@ -196,7 +196,7 @@ class PulseEcoClient:
                 period=period,
                 from_=from_,
                 to=to,
-                type=type,
+                type=type.value,
                 sensor_id=sensor_id,
             )
         )

--- a/pulseeco/client/enums.py
+++ b/pulseeco/client/enums.py
@@ -1,0 +1,82 @@
+import sys
+
+if sys.version_info < (3, 11):
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        def __repr__(self) -> str:
+            return str.__repr__(self.value)
+
+else:  # pragma: no cover
+    from enum import StrEnum
+
+
+class SensorType(StrEnum):
+    # unknown type
+    TYPE_NEG_1 = "-1"
+    # MOEPP measurement station
+    TYPE_0 = "0"
+    # SkopjePulse LoRaWAN based sensor, version 1
+    TYPE_1 = "1"
+    # SkopjePulse WiFi based sensor, version 1
+    TYPE_2 = "2"
+    # pulse.eco WiFi based sensor, version 2
+    TYPE_3 = "3"
+    # pulse.eco LoRaWAN based sensor. version 2
+    TYPE_4 = "4"
+    # pengy device, version 1
+    TYPE_20001 = "20001"
+    # URAD Monitor device
+    TYPE_20002 = "20002"
+    # AirThings platform device
+    TYPE_20003 = "20003"
+    # sensor.community crowdsourced device
+    TYPE_20004 = "20004"
+    # unknown type
+    TYPE_20005 = "20005"
+    # unknown type
+    TYPE_20006 = "20006"
+
+
+class SensorStatus(StrEnum):
+    # A user requested this location with a device ID, but not sending data yet
+    REQUESTED = "REQUESTED"
+    # The sensor is up and running properly
+    ACTIVE = "ACTIVE"
+    # The sensor is up and running properly but not yet confirmed by the community lead
+    ACTIVE_UNCONFIRMED = "ACTIVE_UNCONFIRMED"
+    # The sensor is registered but turned off and ignored
+    INACTIVE = "INACTIVE"
+    # The sensor is registered, but so far not bound to an owner
+    NOT_CLAIMED = "NOT_CLAIMED"
+    # The sensor is registered, but so far not bound to an owner nor confirmed by the community lead
+    NOT_CLAIMED_UNCONFIRMED = "NOT_CLAIMED_UNCONFIRMED"
+    # The sensor is manually removed from evidence in order to keep data sanity
+    BANNED = "BANNED"
+
+
+class DataValueType(StrEnum):
+    NO2 = "no2"
+    NO2_PPB = "no2_ppb"
+    O3 = "o3"
+    SO2 = "so2"
+    CO = "co"
+    CO_PPB = "co_ppb"
+    NH3 = "nh3"
+    NH3_PPM = "nh3_ppm"
+    NH3_PPB = "nh3_ppb"
+    PM25 = "pm25"
+    PM10 = "pm10"
+    PM1 = "pm1"
+    TEMPERATURE = "temperature"
+    HUMIDITY = "humidity"
+    PRESSURE = "pressure"
+    NOISE = "noise"
+    NOISE_DBA = "noise_dba"
+    GAS_RESISTANCE = "gasResistance"
+
+
+class AveragePeriod(StrEnum):
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"

--- a/pulseeco/client/models.py
+++ b/pulseeco/client/models.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import datetime  # noqa: TCH003
+import sys
+import warnings
+from typing import Any, List, Optional
+
+from .enums import (  # noqa: TCH001
+    DataValueType,
+    SensorStatus,
+    SensorType,
+)
+
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated
+else:
+    from typing import Annotated
+
+try:
+    from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, TypeAdapter
+except ImportError:
+    warnings.warn(
+        "`pydantic` is not installed but is required for `PulseEcoClient`"
+        ", it is included in the extra `client`"
+        ", install it with `pip install pulse-eco[client]`",
+        stacklevel=2,
+    )
+    raise
+
+
+class Sensor(BaseModel):
+    sensor_id: str = Field(alias="sensorId", description="The unique ID of the sensor")
+    position: str = Field(
+        description="Latitude and longitude GPS coordinates of the sensor"
+    )
+    comments: str = Field(description="Any other comments about the sensor")
+    type: SensorType = Field(description="The type of the sensor")
+    description: str = Field(description="Short description / nome")
+    status: SensorStatus = Field(description="The current status of the sensor")
+
+
+Sensors = TypeAdapter(List[Sensor])
+
+
+class DataValue(BaseModel):
+    sensor_id: str = Field(alias="sensorId", description="The unique ID of the sensor")
+    stamp: datetime.datetime = Field(
+        description="Timestamp of when the measurement was taken"
+    )
+    type: DataValueType = Field(description="The type of the data value taken")
+    position: Optional[str] = Field(  # noqa: UP007
+        description="Latitude and longitude GPS coordinates of the sensor"
+    )
+    value: int = Field(description="The actual value of the measurement taken")
+    year: Optional[int] = Field(  # noqa: UP007
+        default=None,
+        description="Year when the measurement was taken"
+        ", not included with newer data, prefer stamp",
+    )
+
+
+DataValues = TypeAdapter(List[DataValue])
+
+
+def validate_na(v: Any) -> Any | None:  # noqa: ANN401
+    """Validate `N/A` value."""
+    if v == "N/A":
+        return None
+    return v
+
+
+OverallValue = Annotated[Optional[int], BeforeValidator(validate_na)]
+
+
+class OverallValues(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    no2: OverallValue = None
+    no2_ppb: OverallValue = None
+    o3: OverallValue = None
+    so2: OverallValue = None
+    co: OverallValue = None
+    co_ppb: OverallValue = None
+    nh3: OverallValue = None
+    nh3_ppm: OverallValue = None
+    nh3_ppb: OverallValue = None
+    pm25: OverallValue = None
+    pm10: OverallValue = None
+    pm1: OverallValue = None
+    temperature: OverallValue = None
+    humidity: OverallValue = None
+    pressure: OverallValue = None
+    noise: OverallValue = None
+    noise_dba: OverallValue = None
+    gas_resistance: OverallValue = Field(None, alias="gasResistance")
+
+
+class Overall(BaseModel):
+    city_name: str = Field(alias="cityName", description="The city name")
+    values: OverallValues = Field(description="The overall values for the city")

--- a/pulseeco/client/models.py
+++ b/pulseeco/client/models.py
@@ -18,7 +18,7 @@ else:
 
 try:
     from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, TypeAdapter
-except ImportError:
+except ImportError:  # pragma: no cover
     warnings.warn(
         "`pydantic` is not installed but is required for `PulseEcoClient`"
         ", it is included in the extra `client`"

--- a/pulseeco/enums.py
+++ b/pulseeco/enums.py
@@ -1,82 +1,10 @@
-import sys
-from enum import Enum
+import warnings
 
-if sys.version_info < (3, 11):
+warnings.warn(
+    "Importing from `pulseeco.enums` is deprecated"
+    ", use `pulseeco` or `pulseeco.client.enums` instead",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 
-    class StrEnum(str, Enum):
-        def __repr__(self) -> str:
-            return str.__repr__(self.value)
-
-else:  # pragma: no cover
-    from enum import StrEnum
-
-
-class SensorType(StrEnum):
-    # unknown type
-    TYPE_NEG_1 = "-1"
-    # MOEPP measurement station
-    TYPE_0 = "0"
-    # SkopjePulse LoRaWAN based sensor, version 1
-    TYPE_1 = "1"
-    # SkopjePulse WiFi based sensor, version 1
-    TYPE_2 = "2"
-    # pulse.eco WiFi based sensor, version 2
-    TYPE_3 = "3"
-    # pulse.eco LoRaWAN based sensor. version 2
-    TYPE_4 = "4"
-    # pengy device, version 1
-    TYPE_20001 = "20001"
-    # URAD Monitor device
-    TYPE_20002 = "20002"
-    # AirThings platform device
-    TYPE_20003 = "20003"
-    # sensor.community crowdsourced device
-    TYPE_20004 = "20004"
-    # unknown type
-    TYPE_20005 = "20005"
-    # unknown type
-    TYPE_20006 = "20006"
-
-
-class SensorStatus(StrEnum):
-    # A user requested this location with a device ID, but not sending data yet
-    REQUESTED = "REQUESTED"
-    # The sensor is up and running properly
-    ACTIVE = "ACTIVE"
-    # The sensor is up and running properly but not yet confirmed by the community lead
-    ACTIVE_UNCONFIRMED = "ACTIVE_UNCONFIRMED"
-    # The sensor is registered but turned off and ignored
-    INACTIVE = "INACTIVE"
-    # The sensor is registered, but so far not bound to an owner
-    NOT_CLAIMED = "NOT_CLAIMED"
-    # The sensor is registered, but so far not bound to an owner nor confirmed by the community lead
-    NOT_CLAIMED_UNCONFIRMED = "NOT_CLAIMED_UNCONFIRMED"
-    # The sensor is manually removed from evidence in order to keep data sanity
-    BANNED = "BANNED"
-
-
-class DataValueType(StrEnum):
-    NO2 = "no2"
-    NO2_PPB = "no2_ppb"
-    O3 = "o3"
-    SO2 = "so2"
-    CO = "co"
-    CO_PPB = "co_ppb"
-    NH3 = "nh3"
-    NH3_PPM = "nh3_ppm"
-    NH3_PPB = "nh3_ppb"
-    PM25 = "pm25"
-    PM10 = "pm10"
-    PM1 = "pm1"
-    TEMPERATURE = "temperature"
-    HUMIDITY = "humidity"
-    PRESSURE = "pressure"
-    NOISE = "noise"
-    NOISE_DBA = "noise_dba"
-    GAS_RESISTANCE = "gasResistance"
-
-
-class AveragePeriod(StrEnum):
-    DAY = "day"
-    WEEK = "week"
-    MONTH = "month"
+from .client.enums import *  # noqa: F403

--- a/pulseeco/models.py
+++ b/pulseeco/models.py
@@ -1,75 +1,10 @@
-from __future__ import annotations
+import warnings
 
-import datetime  # noqa: TCH003
-from typing import Any, Optional
+warnings.warn(
+    "Importing from `pulseeco.models` is deprecated"
+    ", use `pulseeco` or `pulseeco.client.models` instead",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
-from typing_extensions import Annotated
-
-from .enums import DataValueType, SensorStatus, SensorType  # noqa: TCH001
-
-
-class Sensor(BaseModel):
-    sensor_id: str = Field(alias="sensorId", description="The unique ID of the sensor")
-    position: str = Field(
-        description="Latitude and longitude GPS coordinates of the sensor"
-    )
-    comments: str = Field(description="Any other comments about the sensor")
-    type: SensorType = Field(description="The type of the sensor")
-    description: str = Field(description="Short description / nome")
-    status: SensorStatus = Field(description="The current status of the sensor")
-
-
-class DataValue(BaseModel):
-    sensor_id: str = Field(alias="sensorId", description="The unique ID of the sensor")
-    stamp: datetime.datetime = Field(
-        description="Timestamp of when the measurement was taken"
-    )
-    type: DataValueType = Field(description="The type of the data value taken")
-    position: Optional[str] = Field(  # noqa: UP007
-        description="Latitude and longitude GPS coordinates of the sensor"
-    )
-    value: int = Field(description="The actual value of the measurement taken")
-    year: Optional[int] = Field(  # noqa: UP007
-        default=None,
-        description="Year when the measurement was taken"
-        ", not included with newer data, prefer stamp",
-    )
-
-
-def validate_na(v: Any) -> Any | None:  # noqa: ANN401
-    """Validate `N/A` value."""
-    if v == "N/A":
-        return None
-    return v
-
-
-OverallValue = Annotated[Optional[int], BeforeValidator(validate_na)]
-
-
-class OverallValues(BaseModel):
-    model_config = ConfigDict(extra="allow")
-
-    no2: OverallValue = None
-    no2_ppb: OverallValue = None
-    o3: OverallValue = None
-    so2: OverallValue = None
-    co: OverallValue = None
-    co_ppb: OverallValue = None
-    nh3: OverallValue = None
-    nh3_ppm: OverallValue = None
-    nh3_ppb: OverallValue = None
-    pm25: OverallValue = None
-    pm10: OverallValue = None
-    pm1: OverallValue = None
-    temperature: OverallValue = None
-    humidity: OverallValue = None
-    pressure: OverallValue = None
-    noise: OverallValue = None
-    noise_dba: OverallValue = None
-    gas_resistance: OverallValue = Field(None, alias="gasResistance")
-
-
-class Overall(BaseModel):
-    city_name: str = Field(alias="cityName", description="The city name")
-    values: OverallValues = Field(description="The overall values for the city")
+from .client.models import *  # noqa: F403

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,22 @@ keywords = [
     "air quality index",
     "air pollution",
 ]
-dependencies = ["requests>=2.31.0", "pydantic>=2,<3"]
+dependencies = []
 
 [project.optional-dependencies]
-test = ["coverage[toml]~=7.3.4", "pytest~=7.4.3", "python-dotenv~=1.0.0"]
+client = ["pydantic>=2,<3"]
+requests = ["requests>=2.31.0"]
+aiohttp = ["aiohttp>=3.9.0"]
+httpx = ["httpx>=0.25.1"]
+all-http = ["pulse-eco[requests,aiohttp,httpx]"]
+test = [
+    "pulse-eco[client,all-http]",
+    "coverage[toml]~=7.3.4",
+    "pytest~=7.4.3",
+    "python-dotenv~=1.0.0",
+]
 types = ["types-requests>=2.31.0"]
-lint = ["pulse-eco[types]", "mypy~=1.8.0", "ruff==0.3.2"]
+lint = ["pulse-eco[client,all-http,types]", "mypy~=1.8.0", "ruff==0.3.2"]
 docs = [
     "mkdocs",
     "mkdocstrings[python]",
@@ -52,7 +62,7 @@ docs = [
     "mkdocs-material",
 ]
 dev = [
-    "pulse-eco[test,lint,docs]",
+    "pulse-eco[client,all-http,test,lint,docs]",
     "pre-commit>=3.5.0",
     "pip-tools>=7.3.0",
     "ipython",
@@ -126,7 +136,7 @@ select = [
     "LOG",
     "RUF",
 ]
-ignore = ["E501", "ANN101", "PLR0913", "PLR0917", "ISC001"]
+ignore = ["E501", "ANN101", "PLR0913", "PLR0917", "ISC001", "TRY003"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["S101", "TCH001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ test = [
     "pulse-eco[client,all-http]",
     "coverage[toml]~=7.3.4",
     "pytest~=7.4.3",
+    "pytest-asyncio~=0.23.5",
     "python-dotenv~=1.0.0",
 ]
 types = ["types-requests>=2.31.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ all-http = ["pulse-eco[requests,aiohttp,httpx]"]
 test = [
     "pulse-eco[client,all-http]",
     "coverage[toml]~=7.3.4",
-    "pytest~=7.4.3",
+    "pytest~=8.1.1",
     "pytest-asyncio~=0.23.5",
     "python-dotenv~=1.0.0",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/test_pulseeco.py
+++ b/tests/test_pulseeco.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import datetime
 
 import pytest
-import requests
 
-from pulseeco import AveragePeriod, PulseEcoClient
+from pulseeco import AveragePeriod, DataValueType, OverallValues, PulseEcoClient, Sensor
 from pulseeco.api.pulse_eco_api import PulseEcoAPI
 from pulseeco.constants import (
     DATA_RAW_MAX_SPAN,
@@ -13,8 +12,6 @@ from pulseeco.constants import (
     PULSE_ECO_PASSWORD_ENV_KEY,
     PULSE_ECO_USERNAME_ENV_KEY,
 )
-from pulseeco.enums import DataValueType
-from pulseeco.models import OverallValues, Sensor
 from pulseeco.utils import split_datetime_span
 
 
@@ -100,27 +97,10 @@ def test_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     assert (
         pulse_eco_api._base_url == custom_pulse_eco_base_url_format  # noqa: SLF001
     ), "`_base_url` should be the same as the one from env vars"
-    assert pulse_eco_api._session.auth == (  # noqa: SLF001
+    assert pulse_eco_api._auth == (  # noqa: SLF001
         custom_pulse_eco_username,
         custom_pulse_eco_password,
-    ), "`_session.auth` should be the same as the credentials from env vars"
-
-
-def test_auth() -> None:
-    pulse_eco_api = PulseEcoAPI(city_name="skopje", auth=("username", "password"))
-    assert pulse_eco_api._session.auth == (  # noqa: SLF001
-        "username",
-        "password",
-    ), "`_session.auth` should be the same as the passed credentials"
-
-
-def test_custom_session() -> None:
-    with requests.Session() as session:
-        session.proxies["protocol"] = "proxy"
-        pulse_eco_api = PulseEcoAPI(city_name="skopje", session=session)
-        assert (
-            pulse_eco_api._session.proxies["protocol"] == "proxy"  # noqa: SLF001
-        ), "`_session` should be the same as the one from the session parameter"
+    ), "`_auth` should be the same as the credentials from env vars"
 
 
 def test_custom_pulse_eco_api() -> None:


### PR DESCRIPTION
Make package more modular

- Remove base dependencies (breaking change), everything is an extra now, even the Pydantic validated client is now opt-in
- Add support for different HTTP clients
- Add async methods
- Reorganize sub-modules, deprecate previous import paths
- Deprecate `session` argument, replaced by `client` and `async_client`
